### PR TITLE
:sparkles: Feat: 치지직 Auth Url 반환 및 Redis CSRF 처리

### DIFF
--- a/src/main/java/com/example/sku_sw/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/sku_sw/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.example.sku_sw.domain.auth.controller;
 
+import com.example.sku_sw.domain.auth.dto.AuthChzzkAuthUrlResDto;
 import com.example.sku_sw.domain.auth.dto.AuthLoginEmailReqDto;
 import com.example.sku_sw.domain.auth.dto.AuthLoginEmailResDto;
 import com.example.sku_sw.domain.auth.dto.AuthLogoutReqDto;
@@ -49,5 +50,17 @@ public class AuthController implements AuthControllerDocs {
     ) {
         AuthRefreshTokenResDto response = authService.refreshToken(authRefreshTokenReqDto);
         return ResponseEntity.ok(GlobalResponse.success("Access Token & Refresh Token 재발급 완료", response));
+    }
+
+    @Override
+    public ResponseEntity<GlobalResponse<AuthChzzkAuthUrlResDto>> getChzzkAuthUrl() {
+        AuthChzzkAuthUrlResDto response = authService.getChzzkAuthUrl();
+        return ResponseEntity.ok(GlobalResponse.success("치지직 인증 URL 조회 성공", response));
+    }
+
+    @Override
+    public ResponseEntity<GlobalResponse<Void>> handleChzzkCallback(String code, String state) {
+        authService.handleChzzkCallback(code, state);
+        return ResponseEntity.ok(GlobalResponse.success("치지직 인증 callback 수신 성공", null));
     }
 }

--- a/src/main/java/com/example/sku_sw/domain/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/com/example/sku_sw/domain/auth/controller/AuthControllerDocs.java
@@ -1,5 +1,6 @@
 package com.example.sku_sw.domain.auth.controller;
 
+import com.example.sku_sw.domain.auth.dto.AuthChzzkAuthUrlResDto;
 import com.example.sku_sw.domain.auth.dto.AuthLoginEmailReqDto;
 import com.example.sku_sw.domain.auth.dto.AuthLoginEmailResDto;
 import com.example.sku_sw.domain.auth.dto.AuthLogoutReqDto;
@@ -8,6 +9,7 @@ import com.example.sku_sw.domain.auth.dto.AuthRefreshTokenResDto;
 import com.example.sku_sw.domain.auth.dto.AuthRegisterEmailReqDto;
 import com.example.sku_sw.global.response.GlobalResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,9 +17,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Auth", description = "인증 관련 API")
 @RequestMapping("/api/v1/auth")
@@ -105,5 +109,48 @@ public interface AuthControllerDocs {
     @PostMapping("/refresh")
     ResponseEntity<GlobalResponse<AuthRefreshTokenResDto>> refreshToken(
             @RequestBody AuthRefreshTokenReqDto authRefreshTokenReqDto
+    );
+
+    @Operation(
+            summary = "치지직 인증 URL 조회",
+            description = """
+                    프론트가 치지직 인증 페이지로 이동할 수 있도록 인증 URL을 반환합니다.
+
+                    [Response Data]
+                    - authUrl: 치지직 계정 연동 인증 URL
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "치지직 인증 URL 조회 성공",
+                    content = @Content(schema = @Schema(implementation = AuthChzzkAuthUrlResDto.class))
+            )
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @GetMapping("/chzzk")
+    ResponseEntity<GlobalResponse<AuthChzzkAuthUrlResDto>> getChzzkAuthUrl();
+
+    @Operation(
+            summary = "치지직 인증 Callback 수신",
+            description = """
+                    치지직 인증 완료 후 redirect 되는 callback 요청을 수신합니다.
+
+                    [Query Parameter]
+                    - code: 치지직 인증 완료 후 전달되는 authorization code
+                    - state: 인증 URL 발급 시 서버가 생성하고 Redis에 저장한 CSRF 방지용 state 값
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "치지직 인증 callback 수신 성공", content = @Content),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 치지직 인증 요청입니다.", content = @Content)
+    })
+    @GetMapping("/chzzk/callback")
+    ResponseEntity<GlobalResponse<Void>> handleChzzkCallback(
+            @Parameter(description = "치지직 인증 authorization code", required = true)
+            @RequestParam("code") String code,
+
+            @Parameter(description = "CSRF 방지용 state 값", required = true)
+            @RequestParam("state") String state
     );
 }

--- a/src/main/java/com/example/sku_sw/domain/auth/dto/AuthChzzkAuthUrlResDto.java
+++ b/src/main/java/com/example/sku_sw/domain/auth/dto/AuthChzzkAuthUrlResDto.java
@@ -1,0 +1,12 @@
+package com.example.sku_sw.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "치지직 인증 URL 응답 DTO")
+public record AuthChzzkAuthUrlResDto(
+        @Schema(description = "치지직 인증 URL", example = "https://chzzk.naver.com/account-interlock?clientId=client-id&redirectUri=https://dev.sku-sw.cloud/api/v1/auth/chzzk/callback&state=550e8400-e29b-41d4-a716-446655440000")
+        String authUrl
+) {
+}

--- a/src/main/java/com/example/sku_sw/domain/auth/enums/AuthErrorCode.java
+++ b/src/main/java/com/example/sku_sw/domain/auth/enums/AuthErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements BaseErrorCode {
     // 400 BAD_REQUEST
     PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    CHZZK_AUTH_STATE_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 치지직 인증 요청입니다."),
 
     // 401 UNAUTHORIZED
     INVALID_LOGIN_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),

--- a/src/main/java/com/example/sku_sw/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/sku_sw/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.example.sku_sw.domain.auth.service;
 
+import com.example.sku_sw.domain.auth.dto.AuthChzzkAuthUrlResDto;
 import com.example.sku_sw.domain.auth.dto.AuthLoginEmailReqDto;
 import com.example.sku_sw.domain.auth.dto.AuthLoginEmailResDto;
 import com.example.sku_sw.domain.auth.dto.AuthLogoutReqDto;
@@ -20,19 +21,33 @@ import com.example.sku_sw.global.util.module.RedisValue;
 import com.example.sku_sw.global.util.module.TokenInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
+    private static final String CHZZK_AUTH_BASE_URL = "https://chzzk.naver.com/account-interlock";
+    private static final String CHZZK_REDIRECT_URI = "https://dev.sku-sw.cloud/api/v1/auth/chzzk/callback";
+    private static final long CHZZK_AUTH_STATE_TTL_MILLIS = 10 * 60 * 1000L;
+
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
+
+    @Value("${chzzk.client-id}")
+    private String chzzkClientId;
+
+    @Value("${chzzk.client-secret}")
+    private String chzzkClientSecret;
 
     /**
      * 이메일 회원가입을 처리하는 함수
@@ -279,6 +294,79 @@ public class AuthService {
 
         log.info("[AuthService] refreshToken() - END | userId: {}, email: {}", redisValue.userId(), redisValue.email());
         return result;
+    }
+
+    /**
+     * 치지직 인증 URL을 생성하는 함수
+     * - clientId, redirectUri, state를 포함한 치지직 계정 연동 URL을 생성한다.
+     * - 생성한 state는 callback 검증을 위해 Redis에 저장한다.
+     * @return : 치지직 인증 URL 응답 DTO
+     */
+    @Transactional(readOnly = true)
+    public AuthChzzkAuthUrlResDto getChzzkAuthUrl() {
+        log.info("[AuthService] getChzzkAuthUrl() - START");
+
+        /*
+            1. 치지직 인증 state 생성
+            - CSRF 방지를 위해 임시 UUID 기반 state 값을 생성한다.
+         */
+        String state = UUID.randomUUID().toString();
+
+        /*
+            2. state Redis 저장
+            - callback 요청 검증을 위해 생성 직후 Redis에 state 값을 저장한다.
+         */
+        redisUtil.setChzzkAuthState(state, CHZZK_AUTH_STATE_TTL_MILLIS);
+
+        /*
+            3. 치지직 인증 URL 생성
+            - clientId, redirectUri, state를 query parameter로 조합한다.
+         */
+        String authUrl = UriComponentsBuilder.fromHttpUrl(CHZZK_AUTH_BASE_URL)
+                .queryParam("clientId", chzzkClientId)
+                .queryParam("redirectUri", CHZZK_REDIRECT_URI)
+                .queryParam("state", state)
+                .build()
+                .toUriString();
+
+        /*
+            4. ResponseDto 생성
+            - 프론트가 바로 redirect에 사용할 수 있도록 치지직 인증 URL을 반환한다.
+         */
+        AuthChzzkAuthUrlResDto result = AuthChzzkAuthUrlResDto.builder()
+                .authUrl(authUrl)
+                .build();
+
+        log.info("[AuthService] getChzzkAuthUrl() - END | state: {}", state);
+        return result;
+    }
+
+    /**
+     * 치지직 인증 callback 요청을 검증하는 함수
+     * - Redis에 저장된 state 존재 여부를 확인해 유효한 인증 요청인지 검증한다.
+     * - state 검증 이후의 토큰 교환 및 저장 단계는 다음 구현에서 진행한다.
+     * @param code : 치지직 인증 authorization code
+     * @param state : callback으로 전달된 state 값
+     */
+    @Transactional
+    public void handleChzzkCallback(String code, String state) {
+        log.info("[AuthService] handleChzzkCallback() - START | code: {}, state: {}", code, state);
+
+        /*
+            1. 치지직 인증 state 검증
+            - Redis에 저장된 state 값이 없으면 유효하지 않은 인증 요청으로 판단한다.
+         */
+        if (!redisUtil.hasChzzkAuthState(state)) {
+            throw new CustomException(AuthErrorCode.CHZZK_AUTH_STATE_INVALID);
+        }
+
+        /*
+            2. 다음 단계 진행 준비
+            - code를 이용한 Access Token / Refresh Token 교환 및 DB 저장은 다음 구현 단계에서 진행한다.
+         */
+        log.debug("[AuthService] handleChzzkCallback() - chzzkClientSecret configured: {}", chzzkClientSecret != null && !chzzkClientSecret.isBlank());
+
+        log.info("[AuthService] handleChzzkCallback() - END | state: {}", state);
     }
 
     /**

--- a/src/main/java/com/example/sku_sw/domain/broadcast/enums/BroadcastErrorCode.java
+++ b/src/main/java/com/example/sku_sw/domain/broadcast/enums/BroadcastErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum BroadcastErrorCode implements BaseErrorCode {
     TOKEN_AUTHORIZATION_FAILED(HttpStatus.BAD_REQUEST, "토큰 인증에 실패했습니다."),
+    CHZZK_AUTH_REQUIRED(HttpStatus.BAD_REQUEST, "치지직 Auth가 필요합니다."),
     BROADCAST_CHARACTER_NOT_SELECTED(HttpStatus.BAD_REQUEST, "선택되지 않은 캐릭터가 방송 시작을 시도했습니다."),
     CHARACTER_ALREADY_BROADCASTING(HttpStatus.BAD_REQUEST, "이미 해당 캐릭터가 방송을 진행 중입니다."),
     NEED_BROADCAST_STREAM_ID(HttpStatus.BAD_REQUEST, "방송 고유 ID가 필요합니다"),

--- a/src/main/java/com/example/sku_sw/domain/broadcast/service/BroadcastService.java
+++ b/src/main/java/com/example/sku_sw/domain/broadcast/service/BroadcastService.java
@@ -66,6 +66,7 @@ public class BroadcastService {
     /**
      * AI 캐릭터 방송 시작
      * - 사용자가 선택한 캐릭터로 방송을 시작한다.
+     * - 치지직 Auth Access Token / Refresh Token이 저장되어 있어야 한다.
      * - 선택되지 않은 캐릭터거나 이미 방송 중인 경우 예외를 발생시킨다.
      * - User row에 Write Lock을 걸어 동시 요청을 직렬화한다.
      * @param userId : 방송을 시작하는 사용자 ID
@@ -83,7 +84,15 @@ public class BroadcastService {
                 .orElseThrow(() -> new CustomException(CharacterErrorCode.USER_NOT_FOUND));
 
         /*
-            2. 선택된 캐릭터 검증
+            2. 치지직 Auth 토큰 저장 여부 확인
+            - 치지직 Auth Access Token / Refresh Token이 모두 저장되어 있어야 방송을 시작할 수 있다.
+         */
+        if (!user.hasChzzkAuthTokens()) {
+            throw new CustomException(BroadcastErrorCode.CHZZK_AUTH_REQUIRED);
+        }
+
+        /*
+            3. 선택된 캐릭터 검증
             - 선택된 캐릭터가 없거나, 요청한 캐릭터가 선택된 캐릭터가 아닌 경우 예외를 발생시킨다.
          */
         if (user.getSelectedCharacterId() == null || !user.getSelectedCharacterId().equals(characterId)) {
@@ -91,14 +100,14 @@ public class BroadcastService {
         }
 
         /*
-            3. 캐릭터 조회 및 소유권 검증
+            4. 캐릭터 조회 및 소유권 검증
             - characterId와 userId로 캐릭터를 조회하고, 존재하지 않으면 CHARACTER_NOT_FOUND 예외를 발생시킨다.
          */
         Character character = characterRepository.findBroadcastRedisCharacterByIdAndUserId(characterId, userId)
                 .orElseThrow(() -> new CustomException(CharacterErrorCode.CHARACTER_NOT_FOUND));
 
         /*
-            4. 해당 캐릭터 방송 중 여부 확인
+            5. 해당 캐릭터 방송 중 여부 확인
             - 이미 BROADCASTING 상태인 방송이 있으면 CHARACTER_ALREADY_BROADCASTING 예외를 발생시킨다.
          */
         if (broadcastRepository.existsByCharacterIdAndStatus(characterId, BroadcastStatus.BROADCASTING)) {
@@ -106,27 +115,27 @@ public class BroadcastService {
         }
 
         /*
-            5. 고유 streamId 생성
+            6. 고유 streamId 생성
             - 16자리 영숫자 랜덤 ID를 생성하고, 중복 시 재생성한다.
          */
         String streamId = streamIdGenerator.generate();
 
         /*
-            6. Broadcast 엔티티 생성 및 저장
+            7. Broadcast 엔티티 생성 및 저장
             - 생성한 streamId와 character로 Broadcast 객체를 생성하고 저장한다.
          */
         Broadcast broadcast = Broadcast.startBroadcast(streamId, character);
         Broadcast savedBroadcast = broadcastRepository.save(broadcast);
 
         /*
-            7. Redis 저장용 DTO 생성 및 커밋 후 저장 예약
+            8. Redis 저장용 DTO 생성 및 커밋 후 저장 예약
             - 방송 시작 DB 커밋이 확정된 이후 Redis에 방송 캐릭터 정보를 저장한다.
          */
         BroadcastCharacterRedisDto redisDto = buildBroadcastCharacterRedisDto(character);
         registerBroadcastRedisSaveAfterCommit(savedBroadcast.getStreamId(), redisDto);
 
         /*
-            8. ResponseDto 생성
+            9. ResponseDto 생성
             - 저장된 Broadcast의 streamId와 startedAt을 포맷하여 응답 DTO를 생성한다.
          */
         BroadcastStartResDto result = BroadcastStartResDto.builder()

--- a/src/main/java/com/example/sku_sw/domain/user/entity/User.java
+++ b/src/main/java/com/example/sku_sw/domain/user/entity/User.java
@@ -40,6 +40,16 @@ public class User {
     @Column(name = "selected_character_id")
     private Long selectedCharacterId;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean chzzkApiAuthorized = false;
+
+    @Column(length = 2000)
+    private String chzzkAuthAccessToken;
+
+    @Column(length = 2000)
+    private String chzzkAuthRefreshToken;
+
     // =========================================
     // [ 비즈니스 함수 ]
     // =========================================
@@ -55,5 +65,24 @@ public class User {
     public void updateSelectedCharacterId(Long selectedCharacterId) {
         this.selectedCharacterId = selectedCharacterId;
     }
-    
+
+    public void updateChzzkAuthTokens(String chzzkAuthAccessToken, String chzzkAuthRefreshToken) {
+        this.chzzkApiAuthorized = true;
+        this.chzzkAuthAccessToken = chzzkAuthAccessToken;
+        this.chzzkAuthRefreshToken = chzzkAuthRefreshToken;
+    }
+
+    public void clearChzzkAuthTokens() {
+        this.chzzkAuthAccessToken = null;
+        this.chzzkAuthRefreshToken = null;
+    }
+
+    public boolean hasChzzkAuthTokens() {
+        return hasText(chzzkAuthAccessToken) && hasText(chzzkAuthRefreshToken);
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
 }

--- a/src/main/java/com/example/sku_sw/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/sku_sw/global/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
             "/api/v1/auth/register/email",
             "/api/v1/auth/login/email",
             "/api/v1/auth/refresh",
+            "/api/v1/auth/chzzk/callback",
             "/v3/api-docs/**",  // Swagger JSON 데이터
             "/swagger-ui/**",   // Swagger UI CSS, JS, 이미지
             "/swagger-ui-custom.html",  // Swagger UI 메인 페이지

--- a/src/main/java/com/example/sku_sw/global/util/RedisUtil.java
+++ b/src/main/java/com/example/sku_sw/global/util/RedisUtil.java
@@ -209,4 +209,30 @@ public class RedisUtil {
     public Boolean hasTokenInBlacklist(String token) {
         return redisTemplate.hasKey("BL:" + jwtUtil.getJtiFromToken(token));
     }
+
+    // ==========================================================
+    // [ CHZZK Auth State ]
+    // ==========================================================
+
+    /**
+     * 치지직 Auth state를 Redis에 저장하는 함수
+     * - Key: CHZZK:STATE:{state}
+     * - Value: VALID
+     * - TTL: callback 검증 가능 시간
+     * @param state : 저장할 state 값
+     * @param durationInMillis : TTL(ms)
+     */
+    public void setChzzkAuthState(String state, long durationInMillis) {
+        String key = "CHZZK:STATE:" + state;
+        redisTemplate.opsForValue().set(key, "VALID", Duration.ofMillis(durationInMillis));
+    }
+
+    /**
+     * 치지직 Auth state 존재 여부를 확인하는 함수
+     * @param state : 조회할 state 값
+     * @return : 존재 여부
+     */
+    public boolean hasChzzkAuthState(String state) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey("CHZZK:STATE:" + state));
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,6 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver # MySQL JDBC 드라이버 클래스 지정
   jpa:
     database: mysql # 사용할 데이터베이스 종류 설정 (MySQL)
-    database-platform: org.hibernate.dialect.MySQLDialect # Hibernate에서 사용할 MySQL 방언(dialect) 설정
     show-sql: false # 실행되는 SQL 쿼리를 콘솔에 출력할지 여부 설정
     properties:
       hibernate:
@@ -29,6 +28,10 @@ jwt:
   access-token-validity-in-ms: 86400000
   # 3달 (1000 * 60 * 60 * 24 * 90)
   refresh-token-validity-in-ms: 7776000000
+
+chzzk:
+  client-id: ${CHZZK_CLIENT_ID}
+  client-secret: ${CHZZK_CLIENT_SECRET}
 
 # ops 설정
 management:


### PR DESCRIPTION
## #️⃣연관된 이슈
- #41 

## 📝작업 내용
- 치지직 Auth 인증 URL을 반환하는 API를 추가했습니다.
- callback 엔드포인트를 추가하고 Redis에 저장한 state 값으로 인증 요청 유효성을 검증하도록 구성했습니다.
- 방송 시작 전 User의 치지직 Access Token / Refresh Token 저장 여부를 확인하고, 없으면 예외를 반환하도록 수정했습니다.
- 치지직 client id / secret 설정값과 callback 접근을 위한 security whitelist를 반영했습니다.